### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,11 @@
 # Exclude nonessential files from dist
+/.docker export-ignore
+/.github export-ignore
+/doc export-ignore
+/example export-ignore
 /tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.lando.yml export-ignore
-.travis.yml export-ignore
+/.php_cs.dist export-ignore
 CONTRIBUTING.md export-ignore
+/docker-compose.yml export-ignore


### PR DESCRIPTION
Remove obsolete files from dist.

Let's save space and trees by removing obsolete files that we do not need on dist.

Removing `docker-compose.yml` will also prevent automatic analysis tools to complain about running on docker with root user.